### PR TITLE
Add support for TCP-based connections

### DIFF
--- a/riemann.cabal
+++ b/riemann.cabal
@@ -22,6 +22,7 @@ library
   exposed-modules:
     Network.Monitoring.Riemann
     Network.Monitoring.Riemann.Types
+    Network.Monitoring.Riemann.TCP
   other-modules:
   build-depends:
                 base              >= 4.8.0     && < 5.0
@@ -30,6 +31,9 @@ library
               , containers        >= 0.4.2.0
               , protobuf          >= 0.2
               , transformers      >= 0.4.3.0   && < 0.5
+              , async             >= 2.1
+              , bytestring        >= 0.10
+              , connection        >= 0.2
               , either
               , errors < 2.0
               , lens

--- a/src/Network/Monitoring/Riemann/TCP.hs
+++ b/src/Network/Monitoring/Riemann/TCP.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE RecordWildCards #-}
+-- | TCP Specific connection handling for monitoring with Riemann
+module Network.Monitoring.Riemann.TCP (
+  module Network.Monitoring.Riemann.Types,
+  TCPClient, makeTCPClientFromConnection, makeTLSClient, makeTCPClient,
+  sendEventTCP, sendQueryTCP, sendEventTCP', sendQueryTCP'
+  ) where
+
+import           Control.Concurrent.Async         (waitCatch, withAsync)
+import           Control.Concurrent.MVar
+import           Control.Exception.Base           (SomeException, bracket)
+import           Control.Lens                     ((&), (.~), (?~), (^.))
+import qualified Data.ByteString                  as BS
+import           Data.Default                     (def)
+import           Data.Monoid
+import           Data.ProtocolBuffers
+import           Data.Serialize.Get
+import           Data.Serialize.Put
+import           Data.Text
+import           Data.Time.Clock                  (getCurrentTime)
+import           Data.Time.Clock.POSIX            (utcTimeToPOSIXSeconds)
+import           Network.Connection
+import           Network.Monitoring.Riemann.Types
+
+-- | An opaque data type for a TCP Riemann client. It currently does not support
+-- connection pooling; concurrent uses will be blocked.
+data TCPClient = TCPClient
+  { conn :: Connection
+  , lock :: MVar () }
+
+-- | Perform an action and catch all synchronous exceptions.
+tryAny :: IO a -> IO (Either SomeException a)
+tryAny action = withAsync action waitCatch
+
+-- | Perform an action while holding a lock (binary semaphore).
+takeLockDo :: MVar () -> IO a -> IO a
+takeLockDo lock action = bracket (takeMVar lock) (\_ -> putMVar lock ()) (const action)
+
+-- | Create a @TCPClient@ from an existing @Connection@.
+makeTCPClientFromConnection :: Connection -> IO TCPClient
+makeTCPClientFromConnection conn = TCPClient conn <$> newMVar ()
+
+-- | Create a @TCPClient@ from host name, port, and @TLSSettings@. The
+-- connection will use TLS.
+makeTLSClient :: String -> Int -> TLSSettings -> IO TCPClient
+makeTLSClient hn po tls = do
+  ctx <- initConnectionContext
+  let params = ConnectionParams hn (fromIntegral po) (Just tls) Nothing
+  TCPClient <$> connectTo ctx params <*> newMVar ()
+
+-- | Create a @TCPClient@ from host name and port. The connection will not use
+-- TLS.
+makeTCPClient :: String -> Int -> IO TCPClient
+makeTCPClient hn po = do
+  ctx <- initConnectionContext
+  let params = ConnectionParams hn (fromIntegral po) Nothing Nothing
+  TCPClient <$> connectTo ctx params <*> newMVar ()
+
+-- | Send a message.
+sendMsg :: TCPClient -> Msg -> IO ()
+sendMsg TCPClient{..} msg = do
+  let bytes = runPut (encodeMessage msg)
+      bytesWithLen = runPut (putWord32be (fromIntegral $ BS.length bytes)  >> putByteString bytes)
+  takeLockDo lock $ connectionPut conn bytesWithLen
+
+-- | Receive a message.
+receiveMsg :: TCPClient -> IO Msg
+receiveMsg TCPClient{..} = do
+  msgBs <- takeLockDo lock $ do
+    msgLenBS <- readExactlyNBytes 4
+    let msgLen = fromIntegral $ runGet' getWord32be msgLenBS
+    readExactlyNBytes msgLen
+  return $ runGet' decodeMessage msgBs
+
+  where readExactlyNBytes n = do
+          bs <- connectionGet conn n
+          if BS.length bs == n then return bs else do
+            nextPart <- readExactlyNBytes (n - BS.length bs)
+            return (bs <> nextPart)
+        runGet' g bs = either (error . ("cannot deserialise: " <>)) id $ runGet g bs
+
+-- | Send an event with the @TCPClient@. If it fails, it will return the
+-- exception in a @Left@ value.
+sendEventTCP' :: TCPClient -> Event -> IO (Either SomeException ())
+sendEventTCP' conn e = tryAny $ do
+  current <- getCurrentTime
+  let now = round (utcTimeToPOSIXSeconds current)
+  let msg = def & events .~ [e & time ?~ now]
+  sendMsg conn msg
+
+-- | Send a query with the @TCPClient@ and wait for a reply. If it fails, it
+-- will return the exception in a @Left@ value.
+sendQueryTCP' :: TCPClient -> Text -> IO (Either SomeException ([State], [Event]))
+sendQueryTCP' conn q = tryAny $ do
+  let msg = def & query .~ Just q
+  sendMsg conn msg
+  rcvd <- receiveMsg conn
+  return (rcvd ^. states, rcvd ^. events)
+
+-- | Send an event with the @TCPClient@. If it fails, it will silently discard
+-- the exception.
+sendEventTCP :: TCPClient -> Event -> IO ()
+sendEventTCP conn e = either (const def) id <$> sendEventTCP' conn e
+
+-- | Send a query with the @TCPClient@ and wait for a reply. If it fails, a
+-- default (i.e. empty) value will be returned.
+sendQueryTCP :: TCPClient -> Text -> IO ([State], [Event])
+sendQueryTCP conn q = either (const def) id <$> sendQueryTCP' conn q


### PR DESCRIPTION
This PR adds support for TCP-based connections. No existing code is touched, so no existing APIs would break. It only adds a new module specific for creating TCP connections and sending events/queries over them. 
